### PR TITLE
logger service is transient now

### DIFF
--- a/libs/logger/CHANGELOG.md
+++ b/libs/logger/CHANGELOG.md
@@ -3,17 +3,23 @@
 **Table of Contents**
 
 <!-- TOC depthFrom:2 depthTo:3 -->
+- [0.2.2 (2021-04-05)](#022-2021-04-05)
+    - [Bug fixes](#bug-fixes)
 
 - [0.2.1 (2021-03-25)](#021-2021-03-25)
-    - [Bug fixes](#bug-fixes)
+    - [Bug fixes](#bug-fixes-1)
 - [0.2.0 (2021-02-09)](#020-2021-02-09)
     - [Features](#features)
 - [0.1.2 (2021-01-28)](#012-2021-01-28)
-    - [Bug fixes](#bug-fixes-1)
-- [0.1.1 (2021-01-11)](#011-2021-01-11)
     - [Bug fixes](#bug-fixes-2)
+- [0.1.1 (2021-01-11)](#011-2021-01-11)
+    - [Bug fixes](#bug-fixes-3)
 
 <!-- /TOC -->
+## 0.2.2 (2021-04-05)
+### Bug fixes
+- Scope of `OMSLogger` is transient now.
+
 
 ## 0.2.1 (2021-03-25)
 

--- a/libs/logger/package.json
+++ b/libs/logger/package.json
@@ -1,9 +1,10 @@
 {
   "name": "@finastra/nestjs-logger",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "contributors": [
     "Razvan Bordeanu <razvan.bordeanu@finastra.com>",
-    "David Boclé <david.bocle@finastra.com>"
+    "David Boclé <david.bocle@finastra.com>",
+    "Vitaliy Markitanov <vitaliy.markitanov@finastra.com>"
   ],
   "main": "index.js",
   "license": "MIT",

--- a/libs/logger/src/logger.module.ts
+++ b/libs/logger/src/logger.module.ts
@@ -1,15 +1,8 @@
-import { Module, Scope } from '@nestjs/common';
+import { Module } from '@nestjs/common';
 import { OMSLogger } from './oms/oms.logger.service';
 
 @Module({
-  providers: [
-    OMSLogger,
-    {
-      provide: OMSLogger,
-      useClass: OMSLogger,
-      scope: Scope.TRANSIENT,
-    },
-  ],
-  exports: [OMSLogger],
+  providers: [ OMSLogger ],
+  exports: [ OMSLogger ],
 })
 export class LoggerModule {}

--- a/libs/logger/src/oms/oms.logger.service.spec.ts
+++ b/libs/logger/src/oms/oms.logger.service.spec.ts
@@ -6,10 +6,10 @@ describe('OMSLogger', () => {
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [OMSLogger],
+      imports: [OMSLogger],
     }).compile();
 
-    service = module.get<OMSLogger>(OMSLogger);
+    service = await module.resolve<OMSLogger>(OMSLogger);
     jest.spyOn(console, 'log').mockImplementation(() => 'test');
 
     process.stdout.isTTY = false;
@@ -58,7 +58,7 @@ describe('OMSLogger - with mocked interactive console', () => {
       providers: [OMSLogger],
     }).compile();
 
-    service = module.get<OMSLogger>(OMSLogger);
+    service = await module.resolve<OMSLogger>(OMSLogger);
     jest.spyOn(console, 'log').mockImplementation(() => 'test');
 
     process.stdout.isTTY = true;

--- a/libs/logger/src/oms/oms.logger.service.ts
+++ b/libs/logger/src/oms/oms.logger.service.ts
@@ -1,6 +1,7 @@
-import { Logger } from '@nestjs/common';
+import { Injectable, Logger, Scope } from '@nestjs/common';
 import { OMSLogLevel } from './OMSLog.interface';
 
+@Injectable({scope: Scope.TRANSIENT})
 export class OMSLogger extends Logger {
   private print(logLevel: OMSLogLevel, message: string, context?: string) {
     let currentContext = context;


### PR DESCRIPTION
There was defect - double service in module providers section.
```  providers: [
    OMSLogger,
    {
      provide: OMSLogger,
      useClass: OMSLogger,
      scope: Scope.TRANSIENT,
    },
```
Even though second registration mark it as Transient, in reality it was not.

Now service marked as Transient on class definition level via annotation `@Injectable({scope: Scope.TRANSIENT})`.

Unit tests updated.
Version updated