### PR TITLE
upgrade passport to 0.6.0

### DIFF
--- a/libs/ffdc-apis/corporate-accounts/package.json
+++ b/libs/ffdc-apis/corporate-accounts/package.json
@@ -16,7 +16,7 @@
     "@nestjs/jwt": "^10.0.1",
     "@nestjs/passport": "^9.0.0",
     "openid-client": "^4.9.0",
-    "passport": "^0.5.3",
+    "passport": "^0.6.0",
     "passport-jwt": "^4.0.0"
   }
 }

--- a/libs/oidc/package.json
+++ b/libs/oidc/package.json
@@ -22,7 +22,7 @@
     "cookie": "^0.5.0",
     "flatted": "^3.2.6",
     "openid-client": "^4.9.0",
-    "passport": "^0.5.3",
+    "passport": "^0.6.0",
     "passport-jwt": "^4.0.0"
   },
   "optionalDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "mongoose": "^6.4.6",
         "npm-force-resolutions": "^0.0.10",
         "openid-client": "^4.9.0",
-        "passport": "^0.5.3",
+        "passport": "^0.6.0",
         "passport-jwt": "^4.0.1",
         "reflect-metadata": "^0.1.13",
         "rimraf": "^3.0.2",
@@ -10714,9 +10714,9 @@
       }
     },
     "node_modules/passport": {
-      "version": "0.5.3",
-      "resolved": "https://nexus.finastra.com/nexus/repository/npm_group/passport/-/passport-0.5.3.tgz",
-      "integrity": "sha512-gGc+70h4gGdBWNsR3FuV3byLDY6KBTJAIExGFXTpQaYfbbcHCBlRRKx7RBQSpqEqc5Hh2qVzRs7ssvSfOpkUEA==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/passport/-/passport-0.6.0.tgz",
+      "integrity": "sha512-0fe+p3ZnrWRW74fe8+SvCyf4a3Pb2/h7gFkQ8yTJpAO50gDzlfjZUZTO1k5Eg9kUct22OxHLqDZoKUWRHOh9ug==",
       "license": "MIT",
       "dependencies": {
         "passport-strategy": "1.x.x",
@@ -21856,9 +21856,9 @@
       "integrity": "sha512-XHXfu/yOQRy9vYOtUDVMN60OEJjW013GoObG1o+xwQTpB9eYJX/BjXMsdW13ZDPruFhYYn0AG22w0xgQMwl3Nw=="
     },
     "passport": {
-      "version": "0.5.3",
-      "resolved": "https://nexus.finastra.com/nexus/repository/npm_group/passport/-/passport-0.5.3.tgz",
-      "integrity": "sha512-gGc+70h4gGdBWNsR3FuV3byLDY6KBTJAIExGFXTpQaYfbbcHCBlRRKx7RBQSpqEqc5Hh2qVzRs7ssvSfOpkUEA==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/passport/-/passport-0.6.0.tgz",
+      "integrity": "sha512-0fe+p3ZnrWRW74fe8+SvCyf4a3Pb2/h7gFkQ8yTJpAO50gDzlfjZUZTO1k5Eg9kUct22OxHLqDZoKUWRHOh9ug==",
       "requires": {
         "passport-strategy": "1.x.x",
         "pause": "0.0.1"

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "mongoose": "^6.4.6",
     "npm-force-resolutions": "^0.0.10",
     "openid-client": "^4.9.0",
-    "passport": "^0.5.3",
+    "passport": "^0.6.0",
     "passport-jwt": "^4.0.1",
     "reflect-metadata": "^0.1.13",
     "rimraf": "^3.0.2",


### PR DESCRIPTION
Bumps passport to 0.6.0 to address CVE-2022-25896 .

Also moves passport from nexus to npm.