### PR TITLE
fix(proxy): allow "Content-Type" & "Accept" headers provided by request

### DIFF
--- a/libs/proxy/package.json
+++ b/libs/proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@finastra/nestjs-proxy",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "contributors": [
     "David Boclé <david.bocle@finastra.com>"
   ],

--- a/libs/proxy/src/services/proxy.service.ts
+++ b/libs/proxy/src/services/proxy.service.ts
@@ -74,10 +74,18 @@ export class ProxyService {
       target: getBaseURL(target),
       headers: {
         ...(token && { authorization: 'Bearer ' + token }),
-        'content-type': 'application/json',
-        accept: 'application/json',
       },
     };
+
+    // Set default "Accept" header if not provided by request headers or is set to "*/*"
+    if (!('accept' in req.headers) || req.headers.accept === '*/*') {
+      defaultOptions.headers['accept'] = 'application/json'
+    }
+
+    // Set default "Content-Type" header if not provided by request headers
+    if (!('content-type' in req.headers)) {
+      defaultOptions.headers['content-type'] = 'application/json'
+    }
 
     // Allow http-server options overriding
     const requestOptions = { ...defaultOptions, ...options };


### PR DESCRIPTION
Do not override headers `Content-Type` and `Accept` if they are provided by the request.

Note: We have noticed that if `Accept` header is not provided, it is set by default to `*/*`.

Fix issue #276